### PR TITLE
Fixed bug where if buffer is already close (e.g. graph windows closed…

### DIFF
--- a/src/misc/io_args.py
+++ b/src/misc/io_args.py
@@ -17,12 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from multiprocessing import Process, Queue, Value
+from multiprocessing import Queue, Process
 
 from dsp.data_processor import DataProcessor
 
 
 class IOArgs:
+    from multiprocessing import Value
     strct = None
 
     def __init__(self, verbose: int = 0, **kwargs):

--- a/src/misc/read_file.py
+++ b/src/misc/read_file.py
@@ -18,9 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from multiprocessing import Value, Process, Queue
+from typing import Iterable
 
 from numpy import dtype
-from typing import Iterable
 
 
 def readFile(bitsPerSample: dtype = None,


### PR DESCRIPTION
… by user), when the clean up action occurs it would throw and uncaught exception sending the sentinel to each dataprocessor. Also, moved imports closer to their points of use, s.t. they're not cluttering up memory if not needed.